### PR TITLE
added wrapper for optimisation purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: build
 .PHONY: build clean
 
 build:
-	$(CC) $(MACROS) $(CFLAGS) janpatch-cli.c -o $(NAME)
+	$(CC) $(MACROS) $(CFLAGS) janpatch-cli.c wrapper.c -o $(NAME)
 
 clean:
 	rm $(NAME)

--- a/janpatch-cli.c
+++ b/janpatch-cli.c
@@ -1,5 +1,13 @@
 #include <stdio.h>
 #include "janpatch.h"
+#include "wrapper.h"
+
+#define BUFFERSIZE 1024
+
+static uint8_t source_buffer[BUFFERSIZE];
+static uint8_t patch_buffer[BUFFERSIZE];
+static uint8_t target_buffer[BUFFERSIZE];
+
 
 int main(int argc, char **argv) {
     if (argc != 3 && argc != 4) {
@@ -8,11 +16,11 @@ int main(int argc, char **argv) {
     }
 
     // Open streams
-    FILE *old = fopen(argv[1], "rb");
+    FILE *source = fopen(argv[1], "rb");
     FILE *patch = fopen(argv[2], "rb");
     FILE *target = argc == 4 ? fopen(argv[3], "wb") : stdout;
 
-    if (!old) {
+    if (!source) {
         printf("Could not open '%s'\n", argv[1]);
         return 1;
     }
@@ -27,15 +35,14 @@ int main(int argc, char **argv) {
 
     // janpatch_ctx contains buffers, and references to the file system functions
     janpatch_ctx ctx = {
-        { (unsigned char*)malloc(1024), 1024 }, // source buffer
-        { (unsigned char*)malloc(1024), 1024 }, // patch buffer
-        { (unsigned char*)malloc(1024), 1024 }, // target buffer
+        { source_buffer, BUFFERSIZE }, // source buffer
+        { patch_buffer, BUFFERSIZE }, // patch buffer
+        { target_buffer, BUFFERSIZE }, // target buffer
 
-        &fread,
-        &fwrite,
-        &fseek,
-        &ftell
+        &cread,
+        &cwrite,
+        &cseek,
     };
 
-    return janpatch(ctx, old, patch, target);
+    return janpatch(ctx, source, patch, target);
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -1,0 +1,38 @@
+//
+// Created by alomaa on 2/1/2018.
+//
+
+#include "wrapper.h"
+
+size_t cread(void *ptr, size_t size, size_t count, FILE *stream, long *cur) {
+    size_t bytesRead = 0;
+
+    fseek(stream, *cur, SEEK_SET);
+
+    bytesRead = fread(ptr, size, count, stream);
+
+    *cur += bytesRead;
+
+    return bytesRead;
+}
+
+size_t cwrite(const void *ptr, size_t size, size_t count, FILE *stream, long *cur) {
+    size_t bytesWritten = 0;
+
+    fseek(stream, *cur, SEEK_SET);
+
+    bytesWritten = fwrite(ptr, size, count, stream);
+
+    *cur += bytesWritten;
+
+    return bytesWritten;
+}
+
+int cseek(long *cur, long int offset, int origin) {
+    if(origin == SEEK_SET){
+        *cur = offset;
+    }else if(origin == SEEK_CUR){
+        *cur += offset;
+    }
+    return 0;
+}

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,17 @@
+//
+// Created by alomaa on 2/1/2018.
+//
+
+#ifndef JANPATCH_MASTER_WRAPPER_H
+#define JANPATCH_MASTER_WRAPPER_H
+
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdint.h>
+
+size_t cread(void *ptr, size_t size, size_t count, FILE *stream, long *cur);
+size_t cwrite(const void *ptr, size_t size, size_t count, FILE *stream, long *cur);
+int    cseek(long* pos, long int offset, int origin);
+    
+#endif //JANPATCH_MASTER_WRAPPER_H


### PR DESCRIPTION
G'day,

We have been utilising your JANPatch implementation for internal purposes in a project.

We encountered an issue with runtime speeds when deploying JANPatch onto our target embedded device, which led us to check CPU usage using KCacheGrind. It took 3 minutes to apply a 256B patch to produce a 3kB target file. A point of optimisation we uncovered was the elimination of ftell() and the spoofing of fseek() through an internal counter mechanism.

We have developed a wrapper to achieve this functionality. Consequently, our performance has improved 26.6x in terms of speed on the target device.

Feel free to review the changes proposed.

Cheers