### PR TITLE
Update processing logic for JoJoDiff v0.8.5

### DIFF
--- a/janpatch.h
+++ b/janpatch.h
@@ -313,93 +313,101 @@ int janpatch(janpatch_ctx ctx, JANPATCH_STREAM *source, JANPATCH_STREAM *patch, 
     int c;
     while ((c = jp_getc(&ctx, &ctx.patch_buffer)) != EOF) {
         if (c == JANPATCH_OPERATION_ESC) {
-            switch ((c = jp_getc(&ctx, &ctx.patch_buffer))) {
-                case JANPATCH_OPERATION_EQL: {
-                    int length = find_length(&ctx, &ctx.patch_buffer);
-                    if (length == -1) {
-                        JANPATCH_ERROR("EQL length invalid\n");
-                        JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
-                        return 1;
-                    }
+            c = jp_getc(&ctx, &ctx.patch_buffer);
+        } else {
+            // Starting from JoJoDiff v0.8.5, the default operation is MOD.
+            // The currently read character from the patch stream is not an ESC,
+            // therefore rewind 1 character in the patch stream and set the
+            // default operation to MOD in order to process that character.
+            jp_fseek(&ctx.patch_buffer, -1, SEEK_CUR);
+            c = JANPATCH_OPERATION_MOD;
+        }
 
-                    JANPATCH_DEBUG("EQL: %d bytes\n", length);
-
-                    for (int ix = 0; ix < length; ix++) {
-                        int r = jp_getc(&ctx, &ctx.source_buffer);
-                        if (r < -1) {
-                            JANPATCH_ERROR("fread returned %d, but expected character\n", r);
-                            JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
-                            return 1;
-                        }
-
-                        jp_putc(r, &ctx, &ctx.target_buffer);
-                    }
-
-                    break;
-                }
-                case JANPATCH_OPERATION_MOD: {
-                    JANPATCH_DEBUG("MOD: ");
-
-                    // MOD means to modify the next series of bytes
-                    // so just write everything (until the next ESC sequence) to the target JANPATCH_STREAM
-                    // but also up the position in the source JANPATCH_STREAM every time
-                    process_mod(&ctx, &ctx.source_buffer, &ctx.patch_buffer, &ctx.target_buffer, true);
-                    break;
-                }
-                case JANPATCH_OPERATION_INS: {
-                    JANPATCH_DEBUG("INS: ");
-                    // INS inserts the sequence in the new JANPATCH_STREAM, but does not up the position of the source JANPATCH_STREAM
-                    // so just write everything (until the next ESC sequence) to the target JANPATCH_STREAM
-
-                    process_mod(&ctx, &ctx.source_buffer, &ctx.patch_buffer, &ctx.target_buffer, false);
-                    break;
-                }
-                case JANPATCH_OPERATION_BKT: {
-                    // BKT = backtrace, seek back in source JANPATCH_STREAM with X bytes...
-                    int length = find_length(&ctx, &ctx.patch_buffer);
-                    if (length == -1) {
-                        JANPATCH_ERROR("BKT length invalid\n");
-                        JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
-                        return 1;
-                    }
-
-                    JANPATCH_DEBUG("BKT: %d bytes\n", -length);
-
-                    jp_fseek(&ctx.source_buffer, -length, SEEK_CUR);
-
-                    break;
-                }
-                case JANPATCH_OPERATION_DEL: {
-                    // DEL deletes bytes, so up the source stream with X bytes
-                    int length = find_length(&ctx, &ctx.patch_buffer);
-                    if (length == -1) {
-                        JANPATCH_ERROR("DEL length invalid\n");
-                        JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
-                        return 1;
-                    }
-
-                    JANPATCH_DEBUG("DEL: %d bytes\n", length);
-
-                    jp_fseek(&ctx.source_buffer, length, SEEK_CUR);
-                    break;
-                }
-                case -1: {
-                    // End of file stream... rewind 1 character and break, this will yield back to main loop
-                    jp_fseek(&ctx.source_buffer, -1, SEEK_CUR);
-                    break;
-                }
-                default: {
-                    JANPATCH_ERROR("Unsupported operator %02x\n", c);
+        switch (c) {
+            case JANPATCH_OPERATION_EQL: {
+                int length = find_length(&ctx, &ctx.patch_buffer);
+                if (length == -1) {
+                    JANPATCH_ERROR("EQL length invalid\n");
                     JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
                     return 1;
                 }
-            }
-        }
-        else {
-            JANPATCH_ERROR("Expected ESC but got %02x\n", c);
-            JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
 
-            return 1;
+                JANPATCH_DEBUG("EQL: %d bytes\n", length);
+
+                for (int ix = 0; ix < length; ix++) {
+                    int r = jp_getc(&ctx, &ctx.source_buffer);
+                    if (r < -1) {
+                        JANPATCH_ERROR("fread returned %d, but expected character\n", r);
+                        JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
+                        return 1;
+                    }
+
+                    jp_putc(r, &ctx, &ctx.target_buffer);
+                }
+
+                break;
+            }
+            case JANPATCH_OPERATION_MOD: {
+                JANPATCH_DEBUG("MOD: ");
+
+                // MOD means to modify the next series of bytes
+                // so just write everything (until the next ESC sequence) to the target JANPATCH_STREAM
+                // but also up the position in the source JANPATCH_STREAM every time
+                process_mod(&ctx, &ctx.source_buffer, &ctx.patch_buffer, &ctx.target_buffer, true);
+                break;
+            }
+            case JANPATCH_OPERATION_INS: {
+                JANPATCH_DEBUG("INS: ");
+                // INS inserts the sequence in the new JANPATCH_STREAM, but does not up the position of the source JANPATCH_STREAM
+                // so just write everything (until the next ESC sequence) to the target JANPATCH_STREAM
+
+                process_mod(&ctx, &ctx.source_buffer, &ctx.patch_buffer, &ctx.target_buffer, false);
+                break;
+            }
+            case JANPATCH_OPERATION_BKT: {
+                // BKT = backtrace, seek back in source JANPATCH_STREAM with X bytes...
+                int length = find_length(&ctx, &ctx.patch_buffer);
+                if (length == -1) {
+                    JANPATCH_ERROR("BKT length invalid\n");
+                    JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
+                    return 1;
+                }
+
+                JANPATCH_DEBUG("BKT: %d bytes\n", -length);
+
+                jp_fseek(&ctx.source_buffer, -length, SEEK_CUR);
+
+                break;
+            }
+            case JANPATCH_OPERATION_DEL: {
+                // DEL deletes bytes, so up the source stream with X bytes
+                int length = find_length(&ctx, &ctx.patch_buffer);
+                if (length == -1) {
+                    JANPATCH_ERROR("DEL length invalid\n");
+                    JANPATCH_ERROR("Positions are, source=%ld patch=%ld new=%ld\n", ctx.source_buffer.position, ctx.patch_buffer.position, ctx.target_buffer.position);
+                    return 1;
+                }
+
+                JANPATCH_DEBUG("DEL: %d bytes\n", length);
+
+                jp_fseek(&ctx.source_buffer, length, SEEK_CUR);
+                break;
+            }
+            case -1: {
+                // End of file stream... rewind 1 character and break, this will yield back to main loop
+                jp_fseek(&ctx.source_buffer, -1, SEEK_CUR);
+                break;
+            }
+            default: {
+                // Breaking change in JoJoDiff v0.8.5:
+                // The ESC-MOD sequence is now the default when a new operation
+                // sequence is needed (at the start of a file or after an EQL,
+                // DEL or BKT operation).
+                // See: https://github.com/janjongboom/janpatch/issues/16#issuecomment-705010958
+                jp_fseek(&ctx.patch_buffer, -2, SEEK_CUR);
+                process_mod(&ctx, &ctx.source_buffer, &ctx.patch_buffer, &ctx.target_buffer, true);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
The ESC-MOD sequence is now the default when a new operation sequence is needed (at the start of a file or after an EQL, DEL or BKT operation).